### PR TITLE
feat(config): налаштувати базову конфігурацію застосунку

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -481,6 +481,30 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pydantic-settings"
+version = "2.11.0"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pydantic_settings-2.11.0-py3-none-any.whl", hash = "sha256:fe2cea3413b9530d10f3a5875adffb17ada5c1e1bab0b2885546d7310415207c"},
+    {file = "pydantic_settings-2.11.0.tar.gz", hash = "sha256:d0e87a1c7d33593beb7194adb8470fc426e95ba02af83a0f23474a04c9a08180"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+typing-inspection = ">=0.4.0"
+
+[package.extras]
+aws-secrets-manager = ["boto3 (>=1.35.0)", "boto3-stubs[secretsmanager]"]
+azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
+gcp-secret-manager = ["google-cloud-secret-manager (>=2.23.1)"]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -961,4 +985,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "eafb03535928207afa86953cede57946f7935347099a6978ca1c065b6955c10f"
+content-hash = "184ba4566d05f80e78050da050e5e59f89cc44cb11e616e4ab8c4e6940a62b70"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi (>=0.117.1,<0.118.0)",
-    "uvicorn[standard] (>=0.37.0,<0.38.0)"
+    "uvicorn[standard] (>=0.37.0,<0.38.0)",
+    "pydantic-settings (>=2.11.0,<3.0.0)"
 ]
 
 

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ("settings",)
+
+from .config import settings

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,0 +1,20 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class BaseSettingsWithConfig(BaseSettings):
+    """Base settings class with common configuration for environment variables."""
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+
+class Settings(BaseSettingsWithConfig):
+    """Main application settings container."""
+
+    pass
+
+
+settings = Settings()


### PR DESCRIPTION
Цей PR додає початкову конфігурацію застосунку:

- додано залежність pydantic-settings
- створено порожній .env.template для змінних оточення
- реалізовано core/config.py з базовим класом Settings

Конфігурація буде розширюватись у наступних змінах.